### PR TITLE
Multi fixes

### DIFF
--- a/Cloudinary/Api.php
+++ b/Cloudinary/Api.php
@@ -7,18 +7,4 @@ namespace Speicher210\CloudinaryBundle\Cloudinary;
  */
 class Api extends \Cloudinary\Api
 {
-    /**
-     * @var Cloudinary
-     */
-    private $cloudinary;
-
-    /**
-     * Constructor.
-     *
-     * @param Cloudinary $cloudinary The cloudinary instance already configured.
-     */
-    public function __construct(Cloudinary $cloudinary)
-    {
-        $this->cloudinary = $cloudinary;
-    }
 }

--- a/Cloudinary/Uploader.php
+++ b/Cloudinary/Uploader.php
@@ -7,19 +7,4 @@ namespace Speicher210\CloudinaryBundle\Cloudinary;
  */
 class Uploader extends \Cloudinary\Uploader
 {
-
-    /**
-     * @var Cloudinary
-     */
-    private $cloudinary;
-
-    /**
-     * Constructor.
-     *
-     * @param Cloudinary $cloudinary The cloudinary instance already configured.
-     */
-    public function __construct(Cloudinary $cloudinary)
-    {
-        $this->cloudinary = $cloudinary;
-    }
 }

--- a/Command/DeleteCommand.php
+++ b/Command/DeleteCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class DeleteCommand extends ContainerAwareCommand
 {
-
     /**
      * {@inheritdoc}
      */
@@ -63,9 +62,9 @@ class DeleteCommand extends ContainerAwareCommand
     }
 
     /**
-     * Remove resources by prefix
+     * Remove resources by prefix.
      *
-     * @param InputInterface $input Console input.
+     * @param InputInterface  $input  Console input.
      * @param OutputInterface $output Console output.
      */
     private function removeByPrefix(InputInterface $input, OutputInterface $output)
@@ -84,7 +83,7 @@ class DeleteCommand extends ContainerAwareCommand
     /**
      * Remove a resource.
      *
-     * @param InputInterface $input Console input.
+     * @param InputInterface  $input  Console input.
      * @param OutputInterface $output Console output.
      */
     private function removeResource(InputInterface $input, OutputInterface $output)
@@ -103,9 +102,9 @@ class DeleteCommand extends ContainerAwareCommand
     /**
      * Output the API response.
      *
-     * @param Response $response The response
-     * @param string $part The part of the response to output.
-     * @param OutputInterface $output The console output.
+     * @param Response        $response The response
+     * @param string          $part     The part of the response to output.
+     * @param OutputInterface $output   The console output.
      */
     private function outputApiResponse(Response $response, $part, OutputInterface $output)
     {

--- a/Command/InfoCommand.php
+++ b/Command/InfoCommand.php
@@ -46,8 +46,8 @@ class InfoCommand extends ContainerAwareCommand
     /**
      * Render the general properties.
      *
-     * @param OutputInterface $output The output.
-     * @param Response $response The API response.
+     * @param OutputInterface $output   The output.
+     * @param Response        $response The API response.
      */
     protected function renderProperties(OutputInterface $output, Response $response)
     {
@@ -64,8 +64,8 @@ class InfoCommand extends ContainerAwareCommand
     /**
      * Render the derived resources.
      *
-     * @param OutputInterface $output The output.
-     * @param array $derivedResources The derived resources.
+     * @param OutputInterface $output           The output.
+     * @param array           $derivedResources The derived resources.
      */
     protected function renderDerivedResources(OutputInterface $output, array $derivedResources)
     {
@@ -73,7 +73,7 @@ class InfoCommand extends ContainerAwareCommand
         $table->setHeaders(
             array(
                 array(new TableCell('Derived resources', array('colspan' => 5))),
-                array('ID', 'Format', 'Size', 'Transformation', 'URL')
+                array('ID', 'Format', 'Size', 'Transformation', 'URL'),
             )
         );
         foreach ($derivedResources as $resource) {
@@ -83,7 +83,7 @@ class InfoCommand extends ContainerAwareCommand
                     $resource['format'],
                     $this->formatSize($resource['bytes']),
                     $resource['transformation'],
-                    $resource['url']
+                    $resource['url'],
                 )
             );
         }
@@ -93,7 +93,7 @@ class InfoCommand extends ContainerAwareCommand
     /**
      * Format the size of a file.
      *
-     * @param integer $bytes The number of bytes.
+     * @param int $bytes The number of bytes.
      *
      * @return string
      */
@@ -101,12 +101,12 @@ class InfoCommand extends ContainerAwareCommand
     {
         $unit = 1024;
         if ($bytes <= $unit) {
-            return $bytes . " b";
+            return $bytes.' b';
         }
         $exp = intval((log($bytes) / log($unit)));
-        $pre = "kMGTPE";
+        $pre = 'kMGTPE';
         $pre = $pre[$exp - 1];
 
-        return sprintf("%.1f %sB", $bytes / pow($unit, $exp), $pre);
+        return sprintf('%.1f %sB', $bytes / pow($unit, $exp), $pre);
     }
 }

--- a/Command/UploadCommand.php
+++ b/Command/UploadCommand.php
@@ -72,8 +72,9 @@ class UploadCommand extends ContainerAwareCommand
     /**
      * Upload a picture to Cloudinary.
      *
-     * @param SplFileInfo $file The file to upload.
-     * @param string $publicId Path where to upload in Cloudinary.
+     * @param SplFileInfo $file     The file to upload.
+     * @param string      $publicId Path where to upload in Cloudinary.
+     *
      * @return array
      */
     protected function uploadFileToCloudinary($file, $publicId)

--- a/DependencyInjection/Compiler/RemoveTwigExtensionPass.php
+++ b/DependencyInjection/Compiler/RemoveTwigExtensionPass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Speicher210\CloudinaryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * This class removes the Twig extension if Twig is not available.
+ */
+class RemoveTwigExtensionPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('twig')) {
+            $container->removeDefinition('twig.extension.cloudinary');
+        }
+    }
+}

--- a/DependencyInjection/Speicher210CloudinaryExtension.php
+++ b/DependencyInjection/Speicher210CloudinaryExtension.php
@@ -5,26 +5,27 @@ namespace Speicher210\CloudinaryBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  */
-class Speicher210CloudinaryExtension extends Extension
+class Speicher210CloudinaryExtension extends ConfigurableExtension
 {
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    protected function loadInternal(array $config, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
-
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        $container->setParameter('speicher210_cloudinary.cloud_name', $config['cloud_name']);
-        $container->setParameter('speicher210_cloudinary.access_identifier.api_key', $config['access_identifier']['api_key']);
-        $container->setParameter('speicher210_cloudinary.access_identifier.api_secret', $config['access_identifier']['api_secret']);
+        $container
+            ->getDefinition('speicher210_cloudinary.cloudinary')
+            ->replaceArgument(0, array(
+                'cloud_name' => $config['cloud_name'],
+                'api_key' => $config['access_identifier']['api_key'],
+                'api_secret' => $config['access_identifier']['api_secret'],
+            ));
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,32 +1,26 @@
 <?xml version="1.0" ?>
-<container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="speicher210_cloudinary.cloudinary.class">Speicher210\CloudinaryBundle\Cloudinary\Cloudinary</parameter>
-        <parameter key="speicher210_cloudinary.api.class">Speicher210\CloudinaryBundle\Cloudinary\Api</parameter>
-        <parameter key="speicher210_cloudinary.uploader.class">Speicher210\CloudinaryBundle\Cloudinary\Uploader</parameter>
-    </parameters>
-
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
     <services>
-        <service id="speicher210_cloudinary.cloudinary" class="%speicher210_cloudinary.cloudinary.class%">
-            <argument type="collection">
-                <argument key="cloud_name">%speicher210_cloudinary.cloud_name%</argument>
-                <argument key="api_key">%speicher210_cloudinary.access_identifier.api_key%</argument>
-                <argument key="api_secret">%speicher210_cloudinary.access_identifier.api_secret%</argument>
-            </argument>
+        <service id="speicher210_cloudinary.cloudinary" class="Speicher210\CloudinaryBundle\Cloudinary\Cloudinary">
+            <argument type="collection" />
         </service>
-        <service id="speicher210_cloudinary.api" class="%speicher210_cloudinary.api.class%">
-            <argument id="speicher210_cloudinary.cloudinary" type="service"/>
+
+        <service id="speicher210_cloudinary.api" class="Speicher210\CloudinaryBundle\Cloudinary\Api">
+            <argument type="service" id="speicher210_cloudinary.cloudinary" />
         </service>
-        <service id="speicher210_cloudinary.uploader" class="%speicher210_cloudinary.uploader.class%">
-            <argument id="speicher210_cloudinary.cloudinary" type="service"/>
+
+        <service id="speicher210_cloudinary.uploader" class="Speicher210\CloudinaryBundle\Cloudinary\Uploader">
+            <argument type="service" id="speicher210_cloudinary.cloudinary" />
         </service>
 
         <service id="twig.extension.cloudinary" class="Speicher210\CloudinaryBundle\Twig\Extension\CloudinaryExtension">
-            <argument type="service" id="speicher210_cloudinary.cloudinary"/>
-            <tag name="twig.extension"/>
+            <argument type="service" id="speicher210_cloudinary.cloudinary" />
+            <tag name="twig.extension" />
         </service>
     </services>
 </container>

--- a/Speicher210CloudinaryBundle.php
+++ b/Speicher210CloudinaryBundle.php
@@ -2,8 +2,17 @@
 
 namespace Speicher210\CloudinaryBundle;
 
+use Speicher210\CloudinaryBundle\DependencyInjection\Compiler\RemoveTwigExtensionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class Speicher210CloudinaryBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RemoveTwigExtensionPass());
+    }
 }

--- a/Tests/DependencyInjection/AbstractSpeicher210CloudinaryExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractSpeicher210CloudinaryExtensionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Speicher210\CloudinaryBundle\Tests\DependencyInjection;
+
+use Speicher210\CloudinaryBundle\DependencyInjection\Speicher210CloudinaryExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class AbstractSpeicher210CloudinaryExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->container->registerExtension($extension = new Speicher210CloudinaryExtension());
+        $this->container->loadFromExtension($extension->getAlias());
+    }
+
+    /**
+     * Loads a configuration.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container     The container.
+     * @param string                                                  $configuration The configuration.
+     */
+    abstract protected function loadConfiguration(ContainerBuilder $container, $configuration);
+
+    public function testCloudinaryService()
+    {
+        $this->loadConfiguration($this->container, 'default');
+        $this->container->compile();
+
+        $cloudinary = $this->container->get('speicher210_cloudinary.cloudinary');
+
+        $this->assertInstanceOf('Speicher210\CloudinaryBundle\Cloudinary\Cloudinary', $cloudinary);
+        $this->assertInstanceOf('Cloudinary', $cloudinary);
+
+        $this->assertDefaultConfig();
+    }
+
+    public function testApiService()
+    {
+        $this->loadConfiguration($this->container, 'default');
+        $this->container->compile();
+
+        $api = $this->container->get('speicher210_cloudinary.api');
+
+        $this->assertInstanceOf('Speicher210\CloudinaryBundle\Cloudinary\Api', $api);
+        $this->assertInstanceOf('Cloudinary\Api', $api);
+
+        $this->assertDefaultConfig();
+    }
+
+    public function testUploaderService()
+    {
+        $this->loadConfiguration($this->container, 'default');
+        $this->container->compile();
+
+        $uploader = $this->container->get('speicher210_cloudinary.uploader');
+
+        $this->assertInstanceOf('Speicher210\CloudinaryBundle\Cloudinary\Uploader', $uploader);
+        $this->assertInstanceOf('Cloudinary\Uploader', $uploader);
+
+        $this->assertDefaultConfig();
+    }
+
+    public function testTwigExtensionService()
+    {
+        $this->loadConfiguration($this->container, 'default');
+        $this->container->compile();
+
+        $service = 'twig.extension.cloudinary';
+
+        $this->assertInstanceOf(
+            'Speicher210\CloudinaryBundle\Twig\Extension\CloudinaryExtension',
+            $this->container->get($service)
+        );
+
+        $this->assertTrue($this->container->getDefinition($service)->hasTag('twig.extension'));
+        $this->assertDefaultConfig();
+    }
+
+    /**
+     * Asserts that the default configuration has been populated.
+     */
+    private function assertDefaultConfig()
+    {
+        $this->assertSame(array(
+            'cloud_name' => 'name',
+            'api_key' => 'key',
+            'api_secret' => 'secret',
+        ), \Cloudinary::config());
+    }
+}

--- a/Tests/DependencyInjection/Compiler/RemoveTwigExtensionPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RemoveTwigExtensionPassTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Speicher210\CloudinaryBundle\Tests\DependencyInjection\Compiler;
+
+use Speicher210\CloudinaryBundle\DependencyInjection\Compiler\RemoveTwigExtensionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RemoveTwigExtensionPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var RemoveTwigExtensionPass
+     */
+    private $compilerPass;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('hasDefinition', 'removeDefinition'))
+            ->getMock();
+
+        $this->compilerPass = new RemoveTwigExtensionPass();
+    }
+
+    public function testProcessWithTwig()
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with($this->identicalTo('twig'))
+            ->will($this->returnValue(true));
+
+        $this->container
+            ->expects($this->never())
+            ->method('removeDefinition')
+            ->with($this->identicalTo('twig.extension.cloudinary'));
+
+        $this->compilerPass->process($this->container);
+    }
+
+    public function testProcessWithoutTwig()
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with($this->identicalTo('twig'))
+            ->will($this->returnValue(false));
+
+        $this->container
+            ->expects($this->once())
+            ->method('removeDefinition')
+            ->with($this->identicalTo('twig.extension.cloudinary'));
+
+        $this->compilerPass->process($this->container);
+    }
+}

--- a/Tests/DependencyInjection/YamlSpeicher210CloudinaryExtensionTest.php
+++ b/Tests/DependencyInjection/YamlSpeicher210CloudinaryExtensionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Speicher210\CloudinaryBundle\Tests\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class YamlSpeicher210CloudinaryExtensionTest extends AbstractSpeicher210CloudinaryExtensionTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadConfiguration(ContainerBuilder $container, $configuration)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Fixtures/Config/Yaml'));
+        $loader->load($configuration.'.yml');
+    }
+}

--- a/Tests/Fixtures/Config/Yaml/default.yml
+++ b/Tests/Fixtures/Config/Yaml/default.yml
@@ -1,0 +1,5 @@
+speicher210_cloudinary:
+    cloud_name: name
+    access_identifier:
+        api_key: key
+        api_secret: secret

--- a/Tests/Twig/Extension/CloudinaryExtensionTest.php
+++ b/Tests/Twig/Extension/CloudinaryExtensionTest.php
@@ -7,15 +7,70 @@ use Speicher210\CloudinaryBundle\Twig\Extension\CloudinaryExtension;
 
 class CloudinaryExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
 
-    public function testGetUrl()
+    /**
+     * @var CloudinaryExtension
+     */
+    private $extension;
+
+    /**
+     * @var Cloudinary
+     */
+    private $cloudinary;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
     {
-        $cloudinary = new Cloudinary(array('cloud_name' => 'test'));
-        $ext = new CloudinaryExtension($cloudinary);
+        $this->cloudinary = new Cloudinary(array('cloud_name' => 'test'));
+        $this->extension = new CloudinaryExtension($this->cloudinary);
 
-        $this->assertEquals(
-            $cloudinary->cloudinary_url('test'),
-            $ext->getUrl('test')
+        $this->twig = new \Twig_Environment(new \Twig_Loader_Filesystem());
+        $this->twig->addExtension($this->extension);
+    }
+
+    public function testUrlFunction()
+    {
+        $template = $this->twig->createTemplate('{{ cloudinary_url(url) }}');
+
+        $this->assertSame(
+            'http://res.cloudinary.com/test/image/upload/id',
+            $template->render(array('url' => 'id'))
+        );
+    }
+
+    public function testUrlFilter()
+    {
+        $template = $this->twig->createTemplate('{{ url | cloudinary_url }}');
+
+        $this->assertSame(
+            'http://res.cloudinary.com/test/image/upload/id',
+            $template->render(array('url' => 'id'))
+        );
+    }
+
+    public function testImageTagFunction()
+    {
+        $template = $this->twig->createTemplate('{{ cloudinary_image_tag(url) }}');
+
+        $this->assertSame(
+            '<img src=\'http://res.cloudinary.com/test/image/upload/id\' />',
+            $template->render(array('url' => 'id'))
+        );
+    }
+
+    public function testImageTagFilter()
+    {
+        $template = $this->twig->createTemplate('{{ url | cloudinary_image_tag }}');
+
+        $this->assertSame(
+            '<img src=\'http://res.cloudinary.com/test/image/upload/id\' />',
+            $template->render(array('url' => 'id'))
         );
     }
 }

--- a/Twig/Extension/CloudinaryExtension.php
+++ b/Twig/Extension/CloudinaryExtension.php
@@ -9,13 +9,10 @@ use Speicher210\CloudinaryBundle\Cloudinary\Cloudinary;
  */
 class CloudinaryExtension extends \Twig_Extension
 {
-
     /**
-     * The cloudinary library.
-     *
      * @var Cloudinary
      */
-    protected $cloudinary;
+    private $cloudinary;
 
     /**
      * Constructor.
@@ -28,42 +25,48 @@ class CloudinaryExtension extends \Twig_Extension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('cloudinary_url', array($this, 'getUrl'))
+            new \Twig_SimpleFunction('cloudinary_url', array($this, 'getUrl')),
+            new \Twig_SimpleFunction('cloudinary_image_tag', array($this, 'getImageTag'), array('is_safe' => array('html'))),
         );
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('cloudinary_url', array($this, 'getUrl'))
+            new \Twig_SimpleFilter('cloudinary_url', array($this, 'getUrl')),
+            new \Twig_SimpleFilter('cloudinary_image_tag', array($this, 'getImageTag'), array('is_safe' => array('html'))),
         );
     }
 
     /**
      * Get the cloudinary URL.
      *
-     * @param string $id Image ID.
-     * @param array $options options for the image.
+     * @param string $id      Image ID.
+     * @param array  $options options for the image.
+     *
      * @return string
      */
     public function getUrl($id, $options = array())
     {
-        return $this->cloudinary->cloudinary_url($id, $options);
+        $cloudinary = $this->cloudinary;
+
+        return $cloudinary::cloudinary_url($id, $options);
     }
 
     /**
      * Get the cloudinary image tag.
      *
-     * @param string $id Image ID.
-     * @param array $options options for the image.
+     * @param string $id      Image ID.
+     * @param array  $options options for the image.
+     *
      * @return string
      */
     public function getImageTag($id, $options = array())
@@ -72,7 +75,7 @@ class CloudinaryExtension extends \Twig_Extension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,15 @@
     "symfony/framework-bundle": "~2.5|~3.0",
     "symfony/console": "~2.5|~3.0",
     "symfony/finder": "~2.5|~3.0",
-    "cloudinary/cloudinary_php": "~1.1",
-    "twig/extensions": "~1.1"
+    "cloudinary/cloudinary_php": "~1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8"
+    "phpunit/phpunit": "~4.8",
+    "symfony/phpunit-bridge": "~2.7|~3.0",
+    "twig/twig": "~1.0"
+  },
+  "suggest": {
+    "twig/twig": "Allow to use the cloudinary_url function/filter"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hey!

This PR fixes the following:

 * Drop hard dependency on the `twig/extensions` package in favor of `twig/twig` (to create a twig extension we just need twig).
 * Make the `twig/twig` dependency optional and so, only load the extension if twig is available via a compiler pass (especially usefull if we use this bundle in a API only context - my case).
 * Remove the cloudinary properties everywhere since we don't need it in classes ( we just inject it in order to be sure cloudinary has been configured) (BC break).
 * Directly call the cloudinary static method in the twig extension instead of using the injected instance since the method is static, let call this one instead of calling a static method not statically.
 * Remove `CloudinaryExtension::getImageTag` method since it is used nowhere (why was it here?) (BC break)
 * Remove container parameters and instead directly inject them in the service (BC break).
 * Drop `*.class` container parameters since Symfony promotes to not add them (BC break).
 * Use `ConfigurableExtension` instead of `Extension` for the DI.
 * Add tests for the dependency injection.
 * Rewrite the twig extension tests in order to really test the filter/function.
 * Add `symfony/phpunit-bridge` package in order to detect deprecated features usage.
 * Run PHP-CS-Fixer.

I know that I introduce some BC breaks but since this bundle is using a pre-stable release format (0.X.X), we can still break BC according to semver. If you want me to add an UPGRADE file, let me know...

Additionally, I don't add command tests because I was lazy :)

Enjoy!