### PR TITLE
Add empty constructor in order to avoid PHP optimization

### DIFF
--- a/Cloudinary/Api.php
+++ b/Cloudinary/Api.php
@@ -7,4 +7,10 @@ namespace Speicher210\CloudinaryBundle\Cloudinary;
  */
 class Api extends \Cloudinary\Api
 {
+    /**
+     * @param Cloudinary $cloudinary
+     */
+    public function __construct(Cloudinary $cloudinary)
+    {
+    }
 }

--- a/Cloudinary/Uploader.php
+++ b/Cloudinary/Uploader.php
@@ -7,4 +7,10 @@ namespace Speicher210\CloudinaryBundle\Cloudinary;
  */
 class Uploader extends \Cloudinary\Uploader
 {
+    /**
+     * @param Cloudinary $cloudinary
+     */
+    public function __construct(Cloudinary $cloudinary)
+    {
+    }
 }


### PR DESCRIPTION
Hey!

In #1, I introduce a bug related to optimization done by PHP. Basically, if there is no constructor in a class and we pass an instance of something to it via the Symfony container, PHP will optimize the code and won't instantiate the injected service. Then, it results that the Cloudinary service is not configured at all.