### PR TITLE
Add custom options support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,9 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('options')
+                  ->prototype('variable')->end()
+                ->end()
         ;
 
         return $treeBuilder;

--- a/Factory/CloudinaryFactory.php
+++ b/Factory/CloudinaryFactory.php
@@ -36,11 +36,14 @@ class CloudinaryFactory
         }
 
         return new Cloudinary(
-            [
+            array_merge(
+              $config['options'],
+              [
                 'cloud_name' => $config['cloud_name'],
                 'api_key' => $config['access_identifier']['api_key'],
                 'api_secret' => $config['access_identifier']['api_secret'],
-            ]
+              ]
+            )
         );
     }
 }


### PR DESCRIPTION
Hello,

This simple PR allow configuration for additional cloudinary parameters. (Cf. https://cloudinary.com/documentation/php_additional_topics#configuration_options)

In my case, I needed the "secure" option to force HTTPS. ex:

speicher210_cloudinary:
    url: cloudinary://my-key:my-secret@my-cloud
    # The next configuration variables should be defined if they are not present in the URL
    # The URL will take precedence
    cloud_name: my-cloud
    options:
        secure: true
