### PR TITLE
Allow configuration of global options

### DIFF
--- a/Twig/Extension/CloudinaryExtension.php
+++ b/Twig/Extension/CloudinaryExtension.php
@@ -57,6 +57,7 @@ class CloudinaryExtension extends \Twig_Extension
     public function getUrl($id, $options = [])
     {
         $cloudinary = $this->cloudinary;
+        $options = array_merge($cloudinary::config(), $options);
 
         return $cloudinary::cloudinary_url($id, $options);
     }
@@ -71,6 +72,8 @@ class CloudinaryExtension extends \Twig_Extension
      */
     public function getImageTag($id, $options = [])
     {
+        $options = array_merge($this->cloudinary::config(), $options);
+
         return cl_image_tag($id, $options);
     }
 
@@ -84,6 +87,8 @@ class CloudinaryExtension extends \Twig_Extension
      */
     public function getVideoTag($id, $options = [])
     {
+        $options = array_merge($this->cloudinary::config(), $options);
+
         return cl_video_tag($id, $options);
     }
 


### PR DESCRIPTION
Hi, this PR builds on top of PR#5, but goes one step further: Allow to configure global options that are evaluated on each of your twig function calls, but can be overwritten optionally.

Example from production:

### Before
`{{ cloudinary_url('folder/image', {'secure' : true, 'type': 'private', 'sign_url' : true, 'version': globally_set_sha_hash}) }}`

### After
`config.yml`:
```
speicher210_cloudinary:
    url: "cloudinary://%cloudinary_key%:%cloudinary_secret%@%cloudinary_name%"
    options:
      secure: true
      sign_url: true
      type: private
      version: '%release_sha%'
```

`template.html.twig`:
`{{ cloudinary_url('folder/image') }}`

You can still set options on a case-by-case basis if you don't want the global options to be evaluated for one particular resource.